### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-# @format
-
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
As of right now, I would rather just run an interactive dependency upgrade every once in a while. Dependabot creates a lot of extra work, when this project doesn't need to live on the bleeding edge.